### PR TITLE
make DockerMachine create method configurable

### DIFF
--- a/src/utils/DockerMachineUtil.js
+++ b/src/utils/DockerMachineUtil.js
@@ -55,11 +55,13 @@ var DockerMachine = {
       return false;
     });
   },
-  create: function () {
+  create: function (driverName, driverFlags) {
     if (util.isWindows()) {
       return util.exec([this.command(), '-D', 'create', '-d', 'virtualbox', '--virtualbox-memory', '2048', NAME]);
     } else {
-      return util.exec([this.command(), '-D', 'create', '-d', 'virtualbox' ,'--virtualbox-boot2docker-url', path.join(process.env.RESOURCES_PATH, 'boot2docker.iso'), '--virtualbox-memory', '2048', NAME]);
+      var cmd = [this.command(), '-D', 'create', '-d', driverName];
+      cmd.push.apply(cmd, driverFlags);
+      return util.exec(cmd);
     }
   },
   start: function () {


### PR DESCRIPTION
Up until now the create method was hard coded for both windows and
Mac. After this patch, the calling function will be able to pass
it the driver to use and the driver flags. One step closer to
configurable drivers.
