### PR TITLE
make create be the same for mac and for windows

### DIFF
--- a/src/utils/DockerMachineUtil.js
+++ b/src/utils/DockerMachineUtil.js
@@ -56,13 +56,10 @@ var DockerMachine = {
     });
   },
   create: function (driverName, driverFlags) {
-    if (util.isWindows()) {
-      return util.exec([this.command(), '-D', 'create', '-d', 'virtualbox', '--virtualbox-memory', '2048', NAME]);
-    } else {
-      var cmd = [this.command(), '-D', 'create', '-d', driverName];
-      cmd.push.apply(cmd, driverFlags);
-      return util.exec(cmd);
-    }
+    var cmd = [this.command(), '-D', 'create', '-d', driverName];
+    cmd.push.apply(cmd, driverFlags);
+    cmd.push(NAME);
+    return util.exec(cmd);
   },
   start: function () {
     return util.exec([this.command(), '-D', 'start', NAME]);


### PR DESCRIPTION
Windows and Mac can share the same create code. We should just make
the driver flag pre-population in the driver configuration propose
different default values for the two platforms.
