### PR TITLE
Have a docker client per set up driver

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -48,7 +48,10 @@ routerContainer.set(router);
 
 // Set up app main menu
 Menu.setApplicationMenu(Menu.buildFromTemplate(template()));
-docker.init();
+Object.keys(docker.clients).forEach(function (key) {
+  docker.clients[key].init();
+});
+
 if (!hub.prompted() && !hub.loggedin()) {
   router.transitionTo('login');
 } else {

--- a/src/components/ContainerHomeLogs.react.js
+++ b/src/components/ContainerHomeLogs.react.js
@@ -20,13 +20,13 @@ module.exports = React.createClass({
     this.update();
     this.scrollToBottom();
     LogStore.on(LogStore.SERVER_LOGS_EVENT, this.update);
-    LogStore.fetch(this.props.container.Name);
+    LogStore.fetch(this.props.container.driverName, this.props.container.Name);
   },
 
   componentWillReceiveProps: function (nextProps) {
     if (this.props.container && nextProps.container && this.props.container.Name !== nextProps.container.Name) {
-      LogStore.detach(this.props.container.Name);
-      LogStore.fetch(nextProps.container.Name);
+      LogStore.detach(this.props.container.driverName, this.props.container.Name);
+      LogStore.fetch(nextProps.container.driverName, nextProps.container.Name);
     }
   },
 
@@ -35,7 +35,7 @@ module.exports = React.createClass({
       return;
     }
 
-    LogStore.detach(this.props.container.Name);
+    LogStore.detach(this.props.container.driverName, this.props.container.Name);
     LogStore.removeListener(LogStore.SERVER_LOGS_EVENT, this.update);
   },
   componentDidUpdate: function () {
@@ -59,7 +59,7 @@ module.exports = React.createClass({
       return;
     }
     this.setState({
-      logs: LogStore.logs(this.props.container.Name)
+      logs: LogStore.logs(this.props.container.driverName, this.props.container.Name)
     });
   },
   render: function () {

--- a/src/components/ContainerLogs.react.js
+++ b/src/components/ContainerLogs.react.js
@@ -17,14 +17,14 @@ module.exports = React.createClass({
     this.update();
     this.scrollToBottom();
     LogStore.on(LogStore.SERVER_LOGS_EVENT, this.update);
-    LogStore.fetch(this.props.container.Name);
+    LogStore.fetch(this.props.container.driverName, this.props.container.Name);
   },
   componentWillUnmount: function() {
     if (!this.props.container) {
       return;
     }
 
-    LogStore.detach(this.props.container.Name);
+    LogStore.detach(this.props.container.driverName, this.props.container.Name);
     LogStore.removeListener(LogStore.SERVER_LOGS_EVENT, this.update);
   },
   componentDidUpdate: function () {
@@ -42,7 +42,7 @@ module.exports = React.createClass({
       return;
     }
     this.setState({
-      logs: LogStore.logs(this.props.container.Name)
+      logs: LogStore.logs(this.props.container.driverName, this.props.container.Name)
     });
   },
   render: function () {

--- a/src/menutemplate.js
+++ b/src/menutemplate.js
@@ -9,6 +9,12 @@ var machine = require('./utils/DockerMachineUtil');
 var dialog = remote.require('dialog');
 import docker from './utils/DockerUtil';
 
+var anyDockerHostSet = function() {
+    return Object.keys(docker.clients).some(function (key) {
+      return !!docker.clients[key].host;
+    });
+};
+
 // main.js
 var MenuTemplate = function () {
   return [
@@ -25,7 +31,7 @@ var MenuTemplate = function () {
       {
         label: 'Preferences',
         accelerator: util.CommandOrCtrl() + '+,',
-        enabled: !!docker.host,
+        enabled: anyDockerHostSet(),
         click: function () {
           metrics.track('Opened Preferences', {
             from: 'menu'
@@ -100,7 +106,7 @@ var MenuTemplate = function () {
       {
         label: 'Open Docker Command Line Terminal',
         accelerator: util.CommandOrCtrl() + '+Shift+T',
-        enabled: !!docker.host,
+        enabled: anyDockerHostSet(),
         click: function() {
           metrics.track('Opened Docker Terminal', {
             from: 'menu'

--- a/src/stores/drivers/SetupVirtualBox.js
+++ b/src/stores/drivers/SetupVirtualBox.js
@@ -17,6 +17,7 @@ var _error = null;
 var _cancelled = false;
 var _retryPromise = null;
 var _requiredSteps = [];
+var NAME = "vbox"
 
 var _steps = [{
   name: 'download',
@@ -214,8 +215,8 @@ var SetupStore = assign(Object.create(EventEmitter.prototype), {
             ip: ip
           };
         }
-        docker.setup(ip, machine.name());
-        yield docker.waitForConnection();
+        docker.addClient(NAME, ip, machine.name());
+        yield docker.clients[NAME].waitForConnection();
         metrics.track('Setup Finished');
         break;
       } catch (err) {

--- a/src/utils/ContainerUtil.js
+++ b/src/utils/ContainerUtil.js
@@ -27,7 +27,7 @@ var ContainerUtil = {
       return {};
     }
     var res = {};
-    var ip = docker.host;
+    var ip = docker.clients[container.driverName].host;
     _.each(container.NetworkSettings.Ports, function (value, key) {
       var dockerPort = key.split('/')[0];
       var localUrl = null;

--- a/src/utils/DockerUtil.js
+++ b/src/utils/DockerUtil.js
@@ -10,7 +10,7 @@ import containerServerActions from '../actions/ContainerServerActions';
 import Promise from 'bluebird';
 import rimraf from 'rimraf';
 
-export default {
+var Docker = {
   host: null,
   client: null,
   placeholders: {},
@@ -497,3 +497,13 @@ export default {
     });
   }
 };
+
+var dockerClients = {};
+
+var addClient = function(driverName, ip, machineName) {
+  dockerClients[driverName] = Object.create(Docker);
+  dockerClients[driverName].setup(ip, machineName);
+};
+
+module.exports.clients = dockerClients;
+module.exports.addClient = addClient;


### PR DESCRIPTION
This adds a map in DockerUtil that will assign a separate docker
client per each driver. The reason for this is that each driver
will be reaching a different VM/Host and thus a different IP.

This patch depends on the UI adding driverName to
props.container.
