### PR TITLE
Use the container driver name to use the right client

### DIFF
--- a/src/actions/ContainerActions.js
+++ b/src/actions/ContainerActions.js
@@ -3,42 +3,42 @@ import dockerUtil from '../utils/DockerUtil';
 
 class ContainerActions {
 
-  destroy (name) {
-    this.dispatch({name});
-    dockerUtil.destroy(name);
+  destroy (driverName, containerName) {
+    this.dispatch({driverName, containerName});
+    dockerUtil.clients[driverName].destroy(containerName);
   }
 
-  rename (name, newName) {
-    this.dispatch({name, newName});
-    dockerUtil.rename(name, newName);
+  rename (driverName, containerName, newContainerName) {
+    this.dispatch({driverName, containerName, newContainerName});
+    dockerUtil.clients[driverName].rename(containerName, newContainerName);
   }
 
-  start (name) {
-    this.dispatch({name});
-    dockerUtil.start(name);
+  start (driverName, containerName) {
+    this.dispatch({driverName, containerName});
+    dockerUtil.clients[driverName].start(containerName);
   }
 
-  stop (name) {
-    this.dispatch({name});
-    dockerUtil.stop(name);
+  stop (driverName, containerName) {
+    this.dispatch({driverName, containerName});
+    dockerUtil.clients[driverName].stop(containerName);
   }
 
-  restart (name) {
-    this.dispatch({name});
-    dockerUtil.restart(name);
+  restart (driverName, containerName) {
+    this.dispatch({driverName, containerName});
+    dockerUtil.clients[driverName].restart(containerName);
   }
 
-  update (name, container) {
-    this.dispatch({name, container});
-    dockerUtil.updateContainer(name, container);
+  update (driverName, name, container) {
+    this.dispatch({driverName, name, container});
+    dockerUtil.clients[driverName].updateContainer(name, container);
   }
 
   clearPending () {
     this.dispatch();
   }
 
-  run (name, repo, tag) {
-    dockerUtil.run(name, repo, tag);
+  run (driverName, name, repo, tag) {
+    dockerUtil.clients[driverName].run(name, repo, tag);
   }
 }
 

--- a/src/components/ContainerDetailsSubheader.react.js
+++ b/src/components/ContainerDetailsSubheader.react.js
@@ -72,19 +72,19 @@ var ContainerDetailsSubheader = React.createClass({
   handleRestart: function () {
     if (!this.disableRestart()) {
       metrics.track('Restarted Container');
-      containerActions.restart(this.props.container.Name);
+      containerActions.restart(this.props.container.driverName, this.props.container.Name);
     }
   },
   handleStop: function () {
     if (!this.disableStop()) {
       metrics.track('Stopped Container');
-      containerActions.stop(this.props.container.Name);
+      containerActions.stop(this.props.container.driverName, this.props.container.Name);
     }
   },
   handleStart: function () {
     if (!this.disableStart()) {
       metrics.track('Started Container');
-      containerActions.start(this.props.container.Name);
+      containerActions.start(this.props.container.driverName, this.props.container.Name);
     }
   },
   handleTerminal: function () {

--- a/src/components/ContainerListItem.react.js
+++ b/src/components/ContainerListItem.react.js
@@ -29,7 +29,7 @@ var ContainerListItem = React.createClass({
           from: 'list',
           type: 'existing'
         });
-        containerActions.destroy(this.props.container.Name);
+        containerActions.destroy(this.props.container.driverName, this.props.container.Name);
       }
     }.bind(this));
   },

--- a/src/components/ContainerSettingsAdvanced.react.js
+++ b/src/components/ContainerSettingsAdvanced.react.js
@@ -22,7 +22,7 @@ var ContainerSettingsAdvanced = React.createClass({
     metrics.track('Saved Advanced Options');
     let tty = this.state.tty;
     let openStdin = this.state.openStdin;
-    containerActions.update(this.props.container.Name, {Tty: tty, OpenStdin: openStdin});
+    containerActions.update(this.props.container.driverName, this.props.container.Name, {Tty: tty, OpenStdin: openStdin});
   },
 
   handleChangeTty: function () {

--- a/src/components/ContainerSettingsGeneral.react.js
+++ b/src/components/ContainerSettingsGeneral.react.js
@@ -76,7 +76,7 @@ var ContainerSettingsGeneral = React.createClass({
       return;
     }
 
-    containerActions.rename(this.props.container.Name, newName);
+    containerActions.rename(this.props.container.driverName, this.props.container.Name, newName);
     this.context.router.transitionTo('containerSettingsGeneral', {name: newName});
     metrics.track('Changed Container Name');
   },
@@ -90,7 +90,7 @@ var ContainerSettingsGeneral = React.createClass({
         list.push(key + '=' + value);
       }
     });
-    containerActions.update(this.props.container.Name, {Env: list});
+    containerActions.update(this.props.container.driverName, this.props.container.Name, {Env: list});
   },
 
   handleChangeEnvKey: function (index, event) {
@@ -143,7 +143,7 @@ var ContainerSettingsGeneral = React.createClass({
           from: 'settings',
           type: 'existing'
         });
-        containerActions.destroy(this.props.container.Name);
+        containerActions.destroy(this.props.container.driverName, this.props.container.Name);
       }
     });
   },

--- a/src/components/ContainerSettingsVolumes.react.js
+++ b/src/components/ContainerSettingsVolumes.react.js
@@ -35,7 +35,7 @@ var ContainerSettingsVolumes = React.createClass({
         return pair[1] + ':' + pair[0];
       });
 
-      containerActions.update(this.props.container.Name, {Binds: binds, Volumes: volumes});
+      containerActions.update(this.props.container.driverName, this.props.container.Name, {Binds: binds, Volumes: volumes});
     });
   },
   handleRemoveVolumeClick: function (dockerVol) {
@@ -51,7 +51,7 @@ var ContainerSettingsVolumes = React.createClass({
     if (index >= 0) {
       binds.splice(index, 1);
     }
-    containerActions.update(this.props.container.Name, {HostConfig: hostConfig, Binds: binds, Volumes: volumes});
+    containerActions.update(this.props.container.driverName, this.props.container.Name, {HostConfig: hostConfig, Binds: binds, Volumes: volumes});
   },
   handleOpenVolumeClick: function (path) {
     metrics.track('Opened Volume Directory', {

--- a/src/components/ImageCard.react.js
+++ b/src/components/ImageCard.react.js
@@ -65,7 +65,7 @@ var ImageCard = React.createClass({
     let repo = this.props.image.namespace === 'library' ? this.props.image.name : this.props.image.namespace + '/' + this.props.image.name;
     // DRIVER NAME
     this.props.driverName = machineDriver;
-    containerActions.run(name, repo, this.state.chosenTag);
+    containerActions.run(this.props.driverName, name, repo, this.state.chosenTag);
     this.transitionTo('containerHome', {name});
   },
   handleMenuOverlayClick: function () {

--- a/src/components/NewContainerPull.react.js
+++ b/src/components/NewContainerPull.react.js
@@ -26,7 +26,7 @@ module.exports = React.createClass({
     });
     containerActions.clearPending();
     let name = containerStore.generateName(this.props.pending.repo);
-    containerActions.run(name, this.props.pending.repo, this.props.pending.tag);
+    containerActions.run(this.props.driverName, name, this.props.pending.repo, this.props.pending.tag);
     this.transitionTo('containerHome', {name});
   },
   render: function () {


### PR DESCRIPTION
It was not completed in the previous patches. This handles it.
